### PR TITLE
Bump client-swift-sdk version for BroadcastExt dependency

### DIFF
--- a/LiveKitExample.xcodeproj/project.pbxproj
+++ b/LiveKitExample.xcodeproj/project.pbxproj
@@ -798,7 +798,7 @@
 			repositoryURL = "https://github.com/livekit/client-sdk-swift";
 			requirement = {
 				kind = exactVersion;
-				version = 1.0.0;
+				version = 1.0.1;
 			};
 		};
 		68816CBF27B4D6BC00E24622 /* XCRemoteSwiftPackageReference "KeychainAccess" */ = {


### PR DESCRIPTION
SampleHandler now depends on LKSampleHandler, added in LK 1.0.1.