### PR TITLE
chat: fix issue with decode of incoming messages

### DIFF
--- a/Shared/Controllers/RoomContext.swift
+++ b/Shared/Controllers/RoomContext.swift
@@ -170,11 +170,10 @@ final class RoomContext: ObservableObject {
     func sendMessage() {
         // Make sure the message is not empty
         guard !textFieldString.isEmpty else { return }
-
-        let roomMessage = ExampleRoomMessage(messageId: UUID().uuidString,
-                                             senderSid: room.localParticipant.sid,
-                                             senderIdentity: room.localParticipant.identity,
-                                             text: textFieldString)
+        let currentDate = Date()
+        let roomMessage = ExampleRoomMessage(id: UUID().uuidString,
+                                             message: textFieldString,
+                                             timestamp: Int(currentDate.timeIntervalSince1970))
         textFieldString = ""
         messages.append(roomMessage)
 
@@ -244,8 +243,12 @@ extension RoomContext: RoomDelegate {
     }
 
     func room(_: Room, participant _: RemoteParticipant?, didReceiveData data: Data, forTopic _: String) {
+        //print("Debug: Received raw data: \(String(data: data, encoding: .utf8) ?? "Invalid data")")
+
         do {
             let roomMessage = try jsonDecoder.decode(ExampleRoomMessage.self, from: data)
+            //print("Debug: Decoded message: \(roomMessage)")
+
             // Update UI from main queue
             Task.detached { @MainActor [weak self] in
                 guard let self else { return }

--- a/Shared/RoomView.swift
+++ b/Shared/RoomView.swift
@@ -97,7 +97,8 @@ struct RoomView: View {
     @State private var canSwitchCameraPosition = false
 
     func messageView(_ message: ExampleRoomMessage) -> some View {
-        let isMe = message.senderSid == room.localParticipant.sid
+        let localSidString = String(describing: room.localParticipant.sid)
+        let isMe = message.id == localSidString
 
         return HStack {
             if isMe {
@@ -106,7 +107,7 @@ struct RoomView: View {
 
             //            VStack(alignment: isMe ? .trailing : .leading) {
             //                Text(message.identity)
-            Text(message.text)
+            Text(message.message)
                 .padding(8)
                 .background(isMe ? Color.lkRed : Color.lkGray3)
                 .foregroundColor(Color.white)

--- a/Shared/Support/ExampleRoomMessage.swift
+++ b/Shared/Support/ExampleRoomMessage.swift
@@ -17,23 +17,15 @@
 import LiveKit
 
 struct ExampleRoomMessage: Identifiable, Equatable, Hashable, Codable {
-    // Identifiable protocol needs param named id
-    var id: String {
-        messageId
-    }
-
-    // message id
-    let messageId: String
-
-    let senderSid: Participant.Sid?
-    let senderIdentity: Participant.Identity?
-    let text: String
+    let id: String
+    let message: String
+    let timestamp: Int
 
     static func == (lhs: Self, rhs: Self) -> Bool {
-        lhs.messageId == rhs.messageId
+        lhs.id == rhs.id
     }
 
     func hash(into hasher: inout Hasher) {
-        hasher.combine(messageId)
+        hasher.combine(id)
     }
 }


### PR DESCRIPTION
This patch can correctly read incoming json from chat so messages can be decoded and displayed.
Outgoing messages are still not working.